### PR TITLE
v2.1.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### v2.1.0
+
+* Added compatibility with Foundry VTT v10
+* Sorted the settings in the import dialog to make them easier to find.
+* Client settings are now correctly exported and imported.
+  * Request: [#10](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/10)
+* Grouped the settings by their module and collapsed them by default.
+  * Request: [#13](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/13)
+* Selecting (or unselecting) a setting will now remember that state across imports, saving you time from choosing just the selections you want.
+  * Request: [#18](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/18)
+
 ### v2.0.7
 
 * Added German translation thanks to brockhaus

--- a/languages/de.json
+++ b/languages/de.json
@@ -23,7 +23,8 @@
       "existingValue": "Bereits existierende Einstellungen, die unverändert sind und deshalb ausgelassen werden:",
       "existingPlayerValues": "Bereits existierende Spieler, die unverändert sind und deshalb ausgelassen werden:",
       "updatedPlayer": "Spieler Einstellungen angepasst für: {name}",
-      "noChanges": "Es gibt keinen Unterschied zwischen der aktuellen Welt und den zu importierenden Einstellungen."
+      "noChanges": "Es gibt keinen Unterschied zwischen der aktuellen Welt und den zu importierenden Einstellungen.",
+      "showSettings": "{count} Einstellungen anzeigen"
     }
   }
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -23,7 +23,8 @@
       "existingValue": "Existing values that are unchanged and will be skipped:",
       "existingPlayerValues": "Existing players that are unchanged and will be skipped:",
       "updatedPlayer": "Updated player settings for: {name}",
-      "noChanges": "There are no differences between the current world and the imported settings."
+      "noChanges": "There are no differences between the current world and the imported settings.",
+      "showSettings": "Show {count} settings"
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -24,9 +24,9 @@
   "flags": {
     "allowBugReporter": true
   },
-  "version": "2.0.7",
+  "version": "2.1.0",
   "minimumCoreVersion": "0.6.0",
-  "compatibleCoreVersion": "9",
+  "compatibleCoreVersion": "10",
   "scripts": [],
   "esmodules": [
     "/scripts/module.js"

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -4,6 +4,11 @@ export const templates = {
   settings: `modules/${name}/templates/settings.html`,
 };
 
+export function isV10orNewer() {
+  const gameVersion = game.version || game.data.version;
+  return gameVersion === '10.0' || isNewerVersion(gameVersion, '10');
+}
+
 export function log(force, ...args) {
   try {
     if (typeof force !== "boolean") {

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -7,6 +7,7 @@ export default class Core extends FormApplication {
    */
   constructor(settings) {
     super();
+    this.settingGroups = new Map();
     this.settings = [];
     this.hasWorldSettings = false;
     this.playerSettings = [];
@@ -14,6 +15,7 @@ export default class Core extends FormApplication {
     this.notChangedSettings = [];
     this.notChangedPlayers = [];
     this.notFoundPlayers = [];
+    this.selectedProperties = game.settings.get(name, 'selected-properties') || {};
 
     if (settings && Array.isArray(settings)) {
       log(false, 'Parsing provided settings', settings);
@@ -25,7 +27,13 @@ export default class Core extends FormApplication {
             switch (setting.type) {
               case Setting.WorldType:
                 if (setting.hasChanges()) {
-                  this.settings.push(setting.value);
+                  if (!this.settingGroups.has(setting.value.group)) {
+                    this.settingGroups.set(setting.value.group, []);
+                  }
+                  this.settingGroups.get(setting.value.group).push(setting.value);
+                  if (typeof this.selectedProperties[setting.value.key] === 'undefined') {
+                    this.selectedProperties[setting.value.key] = true;
+                  }
                   this.hasWorldSettings = true;
                 } else {
                   this.notChangedSettings.push(setting.data.key);
@@ -40,6 +48,18 @@ export default class Core extends FormApplication {
                   this.notFoundPlayers.push(setting.value);
                   break;
                 }
+                for (const [key, val] of Object.entries(setting.value.playerDifferences)) {
+                  const combinedKey = `${setting.value.name}--${key}`;
+                  if (typeof this.selectedProperties[combinedKey] === 'undefined') {
+                    this.selectedProperties[combinedKey] = true;
+                  }
+                }
+                for (const [key, val] of Object.entries(setting.value.playerFlagDifferences)) {
+                  const combinedKey = `${setting.value.name}--flag--${key}`;
+                  if (typeof this.selectedProperties[combinedKey] === 'undefined') {
+                    this.selectedProperties[combinedKey] = true;
+                  }
+                }
                 this.playerSettings.push(setting.value);
                 this.hasPlayerSettings = true;
             }
@@ -50,8 +70,13 @@ export default class Core extends FormApplication {
       });
     }
 
-    log(false, 'Processing world settings', this.settings);
-    log(false, 'Processing player settings', this.playerSettings);
+    this.settings = Object.entries(Object.fromEntries(this.settingGroups));
+    this.settings.sort((a, b) => a[0].localeCompare(b[0]));
+    this.playerSettings.sort((a, b) => a.key.localeCompare(b.key));
+
+    log(true, 'Processing world settings', this.settings);
+    log(true, 'Processing player settings', this.playerSettings);
+    log(true, 'Selected Properties', this.selectedProperties);
   }
 
   static get defaultOptions() {
@@ -75,23 +100,87 @@ export default class Core extends FormApplication {
       notChangedSettings: this.notChangedSettings,
       notChangedPlayers: this.notChangedPlayers,
       notFoundPlayers: this.notFoundPlayers,
+      selectedProperties: this.selectedProperties,
     };
   }
 
   activateListeners(html) {
     super.activateListeners(html);
 
+    const updateCheckboxStates = (el) => {
+      let overall = $(el.closest('tbody')).find('input[type=checkbox].toggle-selections')[0];
+      if ($(el).data()?.type === 'core' || $(el).data()?.type === 'flag') {
+        overall = $(el.closest('fieldset')).find('input[type=checkbox].toggle-selections')[0];
+      }
+
+      if (!overall) {
+        return;
+      }
+
+      const options = $(el.closest('tbody')).find(
+        'input[type=checkbox]:not(.toggle-selections)'
+      );
+
+      var checkedCount = 0;
+      for (var i = 0; i < options.length; i++) {
+        if (options[i].checked) {
+          checkedCount++;
+        }
+      }
+
+      if (checkedCount === 0) {
+        overall.checked = false;
+        overall.indeterminate = false;
+      } else if (checkedCount === options.length) {
+        overall.checked = true;
+        overall.indeterminate = false;
+      } else {
+        overall.checked = false;
+        overall.indeterminate = true;
+      }
+    };
+
     html.on('click', '.close', () => {
       this.close();
     });
 
-    html.on('change', '.toggle-selections', (el) => {
+    html.on('change', '.toggle-all-selections', (el) => {
       $(el.target.closest('fieldset'))
         .find('td input')
-        .prop('checked', el.target.checked);
+        .not(el.target)
+        .prop('checked', el.target.checked)
+        .change();
     });
 
-    html.on('click', '.import', () => {
+    html.on('change', '.toggle-selections', (el) => {
+      $(el.target.closest('tbody'))
+        .find('td input')
+        .not(el.target)
+        .prop('checked', el.target.checked)
+        .change();
+    });
+
+    html.on('click', '.show-settings', (el) => {
+      $(el.target.closest('tbody'))
+        .find('tr')
+        .not(el.target.closest('tr'))
+        .toggleClass('none');
+    });
+
+    html.on('change', 'input[type=checkbox]', (el) => {
+      if (!el.target.name) {
+        return;
+      }
+
+      console.log(`Setting ${el.target.name} to ${el.target.checked}`);
+      const selectedProperties = game.settings.get(name, 'selected-properties');
+      selectedProperties[el.target.name] = el.target.checked;
+      game.settings.set(name, 'selected-properties', selectedProperties);
+
+      updateCheckboxStates(el.target);
+    });
+
+    html.on('click', '.import', async () => {
       for (let field of this.form.getElementsByTagName('fieldset')) {
         let targetType = field.dataset?.type;
         if (!targetType) {
@@ -101,46 +190,52 @@ export default class Core extends FormApplication {
 
         switch (targetType) {
           case 'world':
-            this.importWorldSettings(field);
+            await this.importWorldSettings(field);
             break;
           case 'player':
-            this.importPlayerSettings(field);
+            await this.importPlayerSettings(field);
             break;
         }
       }
 
       this.close();
     });
+
+    html.find('tbody').each((i, el) => {
+      updateCheckboxStates($(el).find('input[type=checkbox]:first'));
+    });
   }
 
-  importWorldSettings(fieldset) {
+  async importWorldSettings(fieldset) {
     let changes = [];
     for (let input of fieldset.elements) {
       if (!input.checked || !input.name) {
         continue;
       }
 
-      let target = input.dataset?.for;
-      if (!this.settings[target]) {
+      const target = input.dataset?.for;
+      if (!target) {
+        continue;
+      }
+
+      const [group, val] = target.split('--');
+      if (!this.settings[group] || !this.settings[group][1] || !this.settings[group][1][val]) {
         log(false, 'Import world settings: could not find target for', input);
         continue;
       }
 
-      log(false, 'Importing world setting', this.settings[target]);
-      changes.push(this.settings[target]);
+      log(false, 'Importing world setting', this.settings[group][1][val]);
+      changes.push(this.settings[group][1][val]);
     }
     if (changes.length) {
-      Core.processSettings(changes).then(() => {
-        ui.notifications.info(
-          game.i18n.localize('forien-copy-environment.updatedReloading'),
-          {},
-        );
+      if (await Core.processSettings(changes)) {
+        ui.notifications.info(game.i18n.localize('forien-copy-environment.updatedReloading'));
         window.setTimeout(window.location.reload.bind(window.location), 5000);
-      });
+      }
     }
   }
 
-  importPlayerSettings(fieldset) {
+  async importPlayerSettings(fieldset) {
     let targetUser = null;
     let changes = {
       flags: {},
@@ -152,13 +247,13 @@ export default class Core extends FormApplication {
 
       let target = input.dataset?.for;
       if (!this.playerSettings[target]) {
-        log(false, 'Import player settings: could not find target for', input);
+        log(true, 'Import player settings: could not find target for', input);
         continue;
       }
 
       let type = input.dataset?.type;
       if (!type) {
-        log(false, 'Import player settings: missing type (core or flag)');
+        log(true, 'Import player settings: missing type (core or flag)');
         continue;
       }
 
@@ -166,33 +261,40 @@ export default class Core extends FormApplication {
         targetUser = game.users.getName(this.playerSettings[target].name);
       }
 
+      const fieldName = input.name.split('--').pop();
+      if (!type) {
+        log(true, 'Import player settings: missing value for', input.name);
+        continue;
+      }
+
       if (type === 'core') {
-        changes[input.name] = this.playerSettings[target].playerDifferences[input.name].newVal;
+        changes[fieldName] =
+          this.playerSettings[target].playerDifferences[fieldName].newVal;
       }
 
       if (type === 'flag') {
-        changes.flags[input.name] = this.playerSettings[target].playerFlagDifferences[input.name].newVal;
+        changes.flags[fieldName] =
+          this.playerSettings[target].playerFlagDifferences[fieldName].newVal;
       }
     }
 
     if (!targetUser) {
-      log(false, 'No targetUser found.');
+      log(true, 'No targetUser found.');
       return;
     }
 
     if (Object.keys(changes).length === 1 && isObjectEmpty(changes.flags)) {
-      log(false, 'No changes selected for', targetUser?.name);
+      log(true, 'No changes selected for', targetUser?.name);
       return;
     }
 
-    log(false, `Updating ${targetUser.name} with`, changes);
-    targetUser.update(changes);
+    log(true, `Updating ${targetUser.name} with`, changes);
+    await targetUser.update(changes);
 
     ui.notifications.info(
       game.i18n.format('forien-copy-environment.import.updatedPlayer', {
         name: targetUser.name,
-      }),
-      {},
+      })
     );
   }
 
@@ -210,7 +312,7 @@ export default class Core extends FormApplication {
   static data() {
     let modules = game.data.modules.filter((m) => m.active);
     let system = game.data.system;
-    let core = game.data.version;
+    let core = game.version || game.data.version;
 
     let message = game.i18n.localize('forien-copy-environment.message');
 
@@ -284,14 +386,23 @@ export default class Core extends FormApplication {
   }
 
   static exportGameSettings() {
-    const excludeModules = game.data.modules.filter(m => m.data?.flags?.noCopyEnvironmentSettings).map(m => m.id) || [];
+    const excludeModules =
+      game.data.modules
+        .filter((m) => m.data?.flags?.noCopyEnvironmentSettings)
+        .map((m) => m.id) || [];
 
     // Return an array with both the world settings and player settings together.
     let data = Array.prototype.concat(
-      game.data.settings.filter(s => !excludeModules.some(e => s.key.startsWith(`${e}.`))).map((s) => ({
-        key: s.key,
-        value: s.value,
-      })),
+      Array.from(game.settings.settings)
+        .filter(([k, v]) =>
+            !excludeModules.some((e) => v.namespace === e) &&
+            game.settings.get(v.namespace, v.key) !== v.default
+        )
+        .map(([k, v]) => ({
+          key: k,
+          value: JSON.stringify(game.settings.get(v.namespace, v.key)),
+        }))
+        .sort((a, b) => a.key.localeCompare(b.key)),
       game.users.map((u) => ({
         name: u.data.name,
         core: {
@@ -331,7 +442,7 @@ export default class Core extends FormApplication {
   }
 
   static async processSettings(settings) {
-    if (isNewerVersion(game.data.version, '0.7.9')) {
+    if (isNewerVersion((game.version || game.data.version), '0.7.9')) {
       const updates = [];
       const creates = [];
       settings.forEach(data => {
@@ -366,14 +477,12 @@ export default class Core extends FormApplication {
             data: creates,
           });
         }
+        return true;
       } catch (e) {
-        log(
-          false,
-          `Settings update could not be dispatched to server.`,
-        );
+        log(true, `Settings update could not be dispatched to server.`);
         console.error(e);
       }
-      return;
+      return false;
     }
     for (const setting of settings) {
       const config = game.settings.settings.get(setting.key);
@@ -387,13 +496,12 @@ export default class Core extends FormApplication {
             action: 'update',
             data: setting,
           });
+          return true;
         } catch (e) {
-          log(
-            false,
-            `Setting key ${setting.key} could not be dispatched to server.`,
-          );
+          log(true, `Setting key ${setting.key} could not be dispatched to server.`);
           console.error(e);
         }
+        return false;
       }
     }
   }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,6 +1,15 @@
 import {name} from './config.js';
 import Core from './core.js';
 
+Hooks.once('init', function(){
+  game.settings.register(name, 'selected-properties', {
+    scope: 'client',
+    config: false,
+    type: Object,
+    default:{}
+  });
+});
+
 Hooks.once('devModeReady', ({registerPackageDebugFlag}) => {
   registerPackageDebugFlag(name);
 });

--- a/scripts/setting.js
+++ b/scripts/setting.js
@@ -60,6 +60,7 @@ export class WorldSetting {
     this.key = setting.key;
     this.value = setting.value;
     this.difference = this.calculateDifference();
+    this.group = this.key.split('.').shift();
   }
 
   hasChanges() {
@@ -71,30 +72,34 @@ export class WorldSetting {
    * @returns {Difference}
    */
   calculateDifference() {
-    let existingSettings = game.data.settings.find((s) => s.key === this.key);
+    const keyParts = this.key.split('.');
+    const namespace = keyParts.shift();
+    const key = keyParts.join('.');
+    let existingSetting = game.settings.get(namespace, key);
     try {
-      // World settings are stored as JSON strings, try to determine if they are
-      // objects that can be compared, rather than string representations.
-      let existingValue = existingSettings?.value;
-      if (existingValue) {
-        existingValue = JSON.parse(existingValue);
-      }
       let newValue = this.value;
       if (newValue) {
         newValue = JSON.parse(newValue);
       }
-      if (typeof existingValue === 'object' && typeof newValue === 'object') {
-        let diff = diffObject(existingValue, newValue);
+      if (typeof existingSetting === 'object' && typeof newValue === 'object') {
+        let diff = diffObject(existingSetting, newValue);
         if (isObjectEmpty(diff)) {
           // No difference in the underlying object.
           return new Difference(this.key, null, null);
         }
       }
+
+      if (existingSetting === newValue) {
+        return new Difference(this.key, null, null);
+      }
+
+      return new Difference(this.key, existingSetting, newValue);
     } catch (e) {
       log(false, 'Could not parse world setting values:', e, this.key);
     }
 
     // Return the difference of the original values, not the parsed values.
+    let existingSettings = game.data.settings.find((s) => s.key === this.key);
     return new Difference(this.key, existingSettings?.value, this.value);
   }
 }

--- a/scripts/setting.js
+++ b/scripts/setting.js
@@ -1,4 +1,4 @@
-import {log} from './config.js';
+import {isV10orNewer, log} from './config.js';
 
 export default class Setting {
   /**
@@ -128,41 +128,40 @@ export class PlayerSetting {
       return this;
     }
 
-    if (setting.core.color !== existingUser.data.color) {
+    const userData = isV10orNewer() ? existingUser : existingUser.data;
+
+    if (setting.core.color !== userData.color) {
       this.playerDifferences.color = new Difference(
         'color',
-        existingUser.data.color,
+        userData.color,
         setting.core.color
       );
     }
 
-    if (setting.core.role !== existingUser.data.role) {
+    if (setting.core.role !== userData.role) {
       this.playerDifferences.role = new Difference(
         'role',
-        existingUser.data.role,
+        userData.role,
         setting.core.role
       );
     }
 
-    if (
-      JSON.stringify(setting.core.permissions) !==
-      JSON.stringify(existingUser.data.permissions)
-    ) {
+    if (JSON.stringify(setting.core.permissions) !== JSON.stringify(userData.permissions)) {
       this.playerDifferences.permissions = new Difference(
         'permissions',
-        existingUser.data.permissions,
+        userData.permissions,
         this.data.core.permissions
       );
     }
 
-    let flagDiff = diffObject(existingUser.data.flags, setting.flags);
+    let flagDiff = diffObject(userData.flags, setting.flags);
     for (const prop in flagDiff) {
       if (!flagDiff.hasOwnProperty(prop)) {
         continue;
       }
       this.playerFlagDifferences[prop] = new Difference(
         prop,
-        existingUser.data.flags[prop],
+        userData.flags[prop],
         flagDiff[prop]
       );
     }

--- a/styles/module.css
+++ b/styles/module.css
@@ -2,6 +2,25 @@
 #forien-copy-environment-settings fieldset th.property {
   text-align: left;
 }
-#forien-copy-environment-settings fieldset td.value {
+#forien-copy-environment-settings fieldset td {
   word-break: break-all;
+  vertical-align: top;
+}
+#forien-copy-environment-settings form {
+  max-height: 100%;
+}
+#forien-copy-environment-settings form tbody {
+  border-bottom: 1px solid #777;
+}
+#forien-copy-environment-settings form tbody tr.none {
+  display: none;
+}
+#forien-copy-environment-settings form tbody tr span.show-settings {
+  text-decoration: underline;
+  cursor: pointer;
+}
+#forien-copy-environment-settings section.import-properties {
+  max-height: calc(100% - 82px);
+  overflow: auto;
+  margin-bottom: 10px;
 }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,30 +1,36 @@
 <form class="{{classes}}" autocomplete="off">
   <h2>{{localize 'forien-copy-environment.intro'}}</h2>
 
+  <section class="import-properties">
   {{#if hasWorldSettings}}
   <fieldset name="input world" data-type="world">
     <legend>{{localize 'forien-copy-environment.import.title'}}</legend>
     <table>
       <thead>
-        <th width="20%" class="property"><label><input type="checkbox" class="toggle-selections" checked>
+        <th width="20%" class="property"><label><input type="checkbox" class="toggle-all-selections">
           {{localize 'forien-copy-environment.import.property'}}</label></th>
         <th width="40%">{{localize 'forien-copy-environment.import.newValue'}}</th>
         <th width="40%">{{localize 'forien-copy-environment.import.currentValue'}}</th>
       </thead>
-      <tbody>
-        {{#each settings}}
-        <tr>
-          <td><label><input name="{{ key }}" id="world-{{@index}}" type="checkbox" data-for="{{ @index }}"
-                data-type="world" checked>{{ key }}</label></td>
-          <td class="value">
-            {{ difference.newString }}
-          </td>
-          <td class="value">
-            {{ difference.oldString }}
-          </td>
-        </tr>
-        {{/each}}
-      </tbody>
+      {{#each settings as |setting|}}
+        <tbody>
+          <tr>
+            <td colspan="3"><label><input type="checkbox" class="toggle-selections"> {{setting.[0]}}</label> <span class="show-settings">({{localize 'forien-copy-environment.import.showSettings' count=setting.[1].length}})</span></td>
+          </tr>
+          {{#each setting.[1]}}
+          <tr class="none">
+            <td width="20%"><label for="world-{{key}}"><input name="{{ key }}" id="world-{{key}}" type="checkbox" data-for="{{ @../index }}--{{ @index }}"
+                  data-type="world" {{checked (lookup @root.selectedProperties key)}}>{{ key }}</label></td>
+            <td width="40%" class="value">
+              <label for="world-{{key}}">{{ difference.newString }}</label>
+            </td>
+            <td width="40%" class="value">
+              <label for="world-{{key}}">{{ difference.oldString }}</label>
+            </td>
+          </tr>
+          {{/each}}
+        </tbody>
+      {{/each}}
     </table>
   </fieldset>
   {{/if}}
@@ -50,29 +56,33 @@
         <th width="40%">{{localize 'forien-copy-environment.import.currentValue'}}</th>
       </thead>
       <tbody>
-        {{#each playerDifferences}}
+        {{#each playerDifferences as |diff|}}
+        {{#with (concat ../name "--" name) as |fkey|}}
         <tr>
-          <td><label><input name="{{ name }}" id="core-{{@../index}}-{{@index}}" type="checkbox"
-                data-for="{{ @../index }}" data-type="core" checked>{{ name }}</label></td>
+          <td><label for="{{fkey}}"><input name="{{fkey}}" id="{{fkey}}" type="checkbox"
+                data-for="{{ @../index }}" data-type="core" {{checked (lookup @root.selectedProperties fkey)}}>{{ diff.name }}</label></td>
           <td class="value">
-            {{ newString }}
+            <label for="{{fkey}}">{{ diff.newString }}
           </td>
           <td class="value">
-            {{ oldString }}
+            <label for="{{fkey}}">{{ diff.oldString }}</label>
           </td>
         </tr>
+        {{/with}}
         {{/each}}
-        {{#each playerFlagDifferences}}
+        {{#each playerFlagDifferences as |diff|}}
+        {{#with (concat ../name "--flag--" name) as |fkey|}}
         <tr>
-          <td><label><input name="{{ name }}" type="checkbox" data-for="{{ @../index }}" data-type="flag"
-                checked>{{ name }}</label></td>
+          <td><label for="{{fkey}}"><input name="{{fkey}}" type="checkbox" id="{{fkey}}" data-for="{{ @../index }}" data-type="flag"
+            {{checked (lookup @root.selectedProperties fkey)}}>{{ diff.name }}</label></td>
           <td class="value">
-            {{ newString }}
+            <label for="{{fkey}}">{{ diff.newString }}</label>
           </td>
           <td class="value">
-            {{ oldString }}
+            <label for="{{fkey}}">{{ diff.oldString }}</label>
           </td>
         </tr>
+        {{/with}}
         {{/each}}
       </tbody>
     </table>
@@ -101,6 +111,7 @@
   {{#unless hasChanges}}
   <p><strong>{{localize 'forien-copy-environment.import.noChanges'}}</strong></p>
   {{/unless}}
+  </section>
 
   <div class="flexrow">
     {{#if hasChanges}}<button type="button" class="import"><i class="fas fa-save"></i>


### PR DESCRIPTION
* Added compatibility with Foundry VTT v10.
* Sorted the settings in the import dialog to make them easier to find.
* Client settings are now correctly exported and imported.
  * Fixes: [#10](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/10)
* Grouped the settings by their module and collapsed them by default.
  * Fixes: [#13](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/13)
* Selecting (or unselecting) a setting will now remember that state across imports, saving you time from choosing just the selections you want.
  * Fixes: [#18](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/18)