### PR TITLE
v2.1.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v2.1.1
+
+* Fixed settings stored in an object not being compared correctly.
+  * Importantly, this makes the "Enabled Modules" setting to be correctly saved and imported.
+
 ### v2.1.0
 
 * Added compatibility with Foundry VTT v10

--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
   "flags": {
     "allowBugReporter": true
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "10",
   "scripts": [],
@@ -49,7 +49,7 @@
       "lang": "de",
       "name": "Deutsch",
       "path": "languages/de.json"
-    }    
+    }
   ],
   "packs": [],
   "system": [],

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -18,7 +18,7 @@ export default class Core extends FormApplication {
     this.selectedProperties = game.settings.get(name, 'selected-properties') || {};
 
     if (settings && Array.isArray(settings)) {
-      log(false, 'Parsing provided settings', settings);
+      log(true, 'Parsing provided settings', settings);
 
       settings.forEach((data) => {
         try {
@@ -395,7 +395,7 @@ export default class Core extends FormApplication {
           const value = game.settings.get(v.namespace, v.key);
           let sameValue = value === v.default;
           if (typeof value === 'object' && typeof v.default === 'object') {
-            sameValue = !Object.keys(diffObject(value, v.default)).length;
+            sameValue = !Object.keys(diffObject(v.default, value)).length && !Object.keys(diffObject(value, v.default)).length;
           }
           return !excludeModules.some((e) => v.namespace === e) && !sameValue;
         })


### PR DESCRIPTION
* Fixed settings stored in an object not being compared correctly.
  * Importantly, this makes the "Enabled Modules" setting to be correctly saved and imported.

Fixes #21 
Fixes #22 
Fixed #23 

Appologies to all who have submitted issues for it, apparently I had the settings wrong for this repository, so I never got notified.