### PR TITLE
v2.1.8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.8
+
+- Exclude "core.compendiumConfiguration" setting from exports due to the folder ID mapping not being consistent across worlds anyway.
+
 ## v2.1.7
 
 - Mark compatible with v11.

--- a/module.json
+++ b/module.json
@@ -22,12 +22,12 @@
   "flags": {
     "allowBugReporter": true
   },
-  "version": "2.1.7",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "11",
+  "version": "2.1.8",
   "compatibility": {
     "minimum": "0.6.0",
-    "verified": "11.301"
+    "verified": "11.305"
   },
   "scripts": [],
   "esmodules": [

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -439,6 +439,12 @@ export default class Core extends FormApplication {
       Array.from(game.settings.settings)
         .filter(([k, v]) => {
           try {
+            if (v.namespace === 'core' && v.key === 'compendiumConfiguration') {
+              // The Compendium Configuration setting maps compendiums to folders, and the FolderIDs
+              // change in a new world, so migrating this value breaks the mapping.
+              return false;
+            }
+
             const value = game.settings.get(v.namespace, v.key);
             let sameValue = value === v.default;
             if (value && typeof value === 'object' && v.default && typeof v.default === 'object') {


### PR DESCRIPTION
- Exclude "core.compendiumConfiguration" setting from exports due to the folder ID mapping not being consistent across worlds anyway.