### PR TITLE
v2.1.9

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.1.9
+
+- Added a module setting to set the maximum number of characters to display when displaying differences.
+  - This is to help with the issue where a "maximum call stack size exceeded" error may occur with very large export files (see [issue #43](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/43)).
+  - The default is 500 characters per difference.
+- Added machine translations for the new setting strings:
+  - German
+  - Japanese
+  - Portuguese
+
 ## v2.1.8
 
 - Exclude "core.compendiumConfiguration" setting from exports due to the folder ID mapping not being consistent across worlds anyway.

--- a/languages/de.json
+++ b/languages/de.json
@@ -6,6 +6,10 @@
       "export": "Einstellungen exportieren",
       "import": "Einstellungen importieren"
     },
+    "settings": {
+      "max-diff": "Anzahl von Charakteren",
+      "max-diff-hint": "Maximale Anzahl der pro Unterschied anzuzeigenden Zeichen. Auf 0 setzen, um alle anzuzeigen."
+    },
     "title": "Einstellungen importieren",
     "intro": "Bitte wähle aus, welche Welt- und Spieler-Einstellungen Du importieren möchtest.",
     "message": "Die Liste wurde generiert mit Forien's Copy Environment: https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment",

--- a/languages/en.json
+++ b/languages/en.json
@@ -6,6 +6,10 @@
       "export": "Export Settings",
       "import": "Import Settings"
     },
+    "settings": {
+      "max-diff": "Number of characters",
+      "max-diff-hint": "Maximum number of characters to show per difference. Set to 0 to show all."
+    },
     "title": "Import Settings",
     "intro": "This form allows you to select which world and player settings you want to import.",
     "message": "List generated with Forien's Copy Environment: https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment",

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -6,6 +6,10 @@
       "export": "設定のエクスポート",
       "import": "設定のインポート"
     },
+    "settings": {
+      "max-diff": "文字数",
+      "max-diff-hint": "差異ごとに表示する最大文字数。 すべてを表示するには 0 に設定します。"
+    },
     "title": "インポート設定",
     "intro": "このフォームでは、ワールドとプレイヤーのどの設定をインポートするかを選択します。",
     "message": "このリストは「Forien's Copy Environment」で作成されました： https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment",

--- a/languages/pt.json
+++ b/languages/pt.json
@@ -6,6 +6,10 @@
       "export": "Exportar Configurações",
       "import": "Importar Configurações"
     },
+    "settings": {
+      "max-diff": "Número de caracteres",
+      "max-diff-hint": "Número máximo de caracteres a serem exibidos por diferença. Defina como 0 para mostrar tudo."
+    },
     "title": "Importar Configurações",
     "intro": "Este formulário permite que você selecione quais configurações do mundo e jogador você deseja importar.",
     "message": "Lista gerada com Forien's Copy Environment: https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment",

--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
   },
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "11",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "compatibility": {
     "minimum": "0.6.0",
     "verified": "11.305"

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -1,4 +1,4 @@
-import {name, isV10orNewer, templates, log} from './config.js';
+import { name, isV10orNewer, templates, log } from './config.js';
 import Setting from './setting.js';
 
 export default class Core extends FormApplication {
@@ -513,6 +513,7 @@ export default class Core extends FormApplication {
         coreSettings.render(true);
       } catch (e) {
         console.error('Copy Environment | Could not parse import data.', e);
+        console.error('Copy Environment | If you see an error for "maximum call stack size exceeded", try reducing the "Number of Characters" setting.');
       }
     });
   }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -8,6 +8,16 @@ Hooks.once('init', function () {
     type: Object,
     default: {},
   });
+
+  game.settings.register(name, 'diff-length', {
+    scope: 'world',
+    config: true,
+    type: Number,
+    default: 500,
+    name: "forien-copy-environment.settings.max-diff",
+    hint: "forien-copy-environment.settings.max-diff-hint",
+    requiresReload: false,
+  });
 });
 
 Hooks.once('devModeReady', ({registerPackageDebugFlag}) => {

--- a/scripts/setting.js
+++ b/scripts/setting.js
@@ -1,4 +1,4 @@
-import {isV10orNewer, log} from './config.js';
+import {isV10orNewer, name as moduleName} from './config.js';
 
 export default class Setting {
   /**
@@ -214,10 +214,21 @@ export class Difference {
   constructor(name, oldValue, newValue) {
     this.name = name;
     if (oldValue !== newValue) {
+      let diffSize = game.settings.get(moduleName, "diff-length");
+      if (diffSize < 0) {
+        diffSize = 0;
+      }
+
       this.oldVal = oldValue;
       this.oldString = JSON.stringify(oldValue);
+      if (diffSize && this.oldString?.length > diffSize) {
+        this.oldString = this.oldString.substring(0, diffSize) + '...';
+      }
       this.newVal = newValue;
       this.newString = JSON.stringify(newValue);
+      if (diffSize && this.newString?.length > diffSize) {
+        this.newString = this.newString.substring(0, diffSize) + '...';
+      }
     }
   }
 


### PR DESCRIPTION
- Added a module setting to set the maximum number of characters to display when displaying differences.
  - This is to help with the issue where a "maximum call stack size exceeded" error may occur with very large export files (see [issue #43](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/43)).
  - The default is 500 characters per difference.
- Added machine translations for the new setting strings:
  - German
  - Japanese
  - Portuguese