### PR TITLE
v2.2.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.2.2
+
+- Ignore "core.time" and "pf2e.worldClock.worldCreatedOn" values by default.
+  - These values can still be selected in from the importer dialog but will be unselected by default.
+  - You may run `game.settings.set('forien-copy-environment', 'selected-properties', undefined);` as a script macro to reset the values to their default.
+  - See [issue #53](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/53).
+
 ## v2.2.1
 
 - v12 compatibility.

--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
   },
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "12",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "compatibility": {
     "minimum": "0.6.0",
     "verified": "12"

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -15,7 +15,10 @@ export default class Core extends FormApplication {
     this.notChangedSettings = [];
     this.notChangedPlayers = [];
     this.notFoundPlayers = [];
-    this.selectedProperties = game.settings.get(name, 'selected-properties') || {};
+    this.selectedProperties = game.settings.get(name, 'selected-properties') || {
+      'core.time': false,
+      'pf2e.worldClock.worldCreatedOn': false,
+    };
     this.supportingData = {};
 
     if (settings && Array.isArray(settings)) {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -6,7 +6,10 @@ Hooks.once('init', function () {
     scope: 'client',
     config: false,
     type: Object,
-    default: {},
+    default: {
+      'core.time': false,
+      'pf2e.worldClock.worldCreatedOn': false,
+    },
   });
 
   game.settings.register(name, 'diff-length', {


### PR DESCRIPTION
- Ignore "core.time" and "pf2e.worldClock.worldCreatedOn" values by default.
  - These values can still be selected in from the importer dialog but will be unselected by default.
  - You may run `game.settings.set('forien-copy-environment', 'selected-properties', undefined);` as a script macro to reset the values to their default.
  - See [issue #53](https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues/53).