### PR TITLE
V13 support

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,9 +1,7 @@
 {
   "id": "forien-copy-environment",
-  "name": "forien-copy-environment",
   "title": "Forien's Copy Environment",
   "description": "Allows for copying list of system/modules and versions, and gives ability to export/import game and player settings",
-  "author": "Blair McMillan",
   "authors": [
     {
       "name": "Blair McMillan",
@@ -19,17 +17,11 @@
   "url": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment",
   "bugs": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/issues",
   "changelog": "https://github.com/League-of-Foundry-Developers/foundryvtt-forien-copy-environment/blob/master/changelog.md",
-  "flags": {
-    "allowBugReporter": true
-  },
-  "minimumCoreVersion": "0.6.0",
-  "compatibleCoreVersion": "12",
-  "version": "2.2.4",
+  "version": "3.0.0",
   "compatibility": {
-    "minimum": "0.6.0",
-    "verified": "12"
+    "minimum": "13",
+    "verified": "13"
   },
-  "scripts": [],
   "esmodules": [
     "/scripts/module.js"
   ],

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -4,11 +4,6 @@ export const templates = {
   settings: `modules/${name}/templates/settings.html`,
 };
 
-export function isV10orNewer() {
-  const gameVersion = game.version || game.data.version;
-  return gameVersion === '10.0' || foundry.utils.isNewerVersion(gameVersion, '10');
-}
-
 export function log(force, ...args) {
   try {
     if (typeof force !== "boolean") {

--- a/scripts/core.js
+++ b/scripts/core.js
@@ -1,7 +1,8 @@
 import { name, templates, log } from './config.js';
 import Setting from './setting.js';
 
-export default class Core extends FormApplication {
+// @todo refactor into ApplicationV2 before Foundry v16
+export default class Core extends foundry.appv1.api.FormApplication {
   /**
    * @param {Array.<Object>} settings Read from previously exported settings
    */
@@ -347,7 +348,7 @@ export default class Core extends FormApplication {
 
     let jsonStr = JSON.stringify(data, null, 2);
 
-    saveDataToFile(jsonStr, 'application/json', filename);
+    foundry.utils.saveDataToFile(jsonStr, 'application/json', filename);
   }
 
   static getText() {
@@ -522,7 +523,7 @@ export default class Core extends FormApplication {
       return;
     }
 
-    readTextFromFile(file).then(async (result) => {
+    foundry.utils.readTextFromFile(file).then(async (result) => {
       try {
         const settings = JSON.parse(result);
         let coreSettings = new Core(settings);

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -28,7 +28,7 @@ Hooks.once('devModeReady', ({registerPackageDebugFlag}) => {
 });
 
 Hooks.on('renderSettings', function (app, html, data) {
-  new ContextMenu(html, 'div.game-system, ul#game-details', [
+  new foundry.applications.ux.ContextMenu.implementation(html, '#settings section.info', [
     {
       name: game.i18n.localize('forien-copy-environment.menu.copy'),
       icon: '<i class="far fa-copy"></i>',
@@ -73,5 +73,5 @@ Hooks.on('renderSettings', function (app, html, data) {
         }
       },
     },
-  ]);
+  ], {jQuery: false});
 });

--- a/scripts/setting.js
+++ b/scripts/setting.js
@@ -1,4 +1,4 @@
-import {isV10orNewer, name as moduleName} from './config.js';
+import {name as moduleName} from './config.js';
 
 export default class Setting {
   /**
@@ -141,7 +141,7 @@ export class PlayerSetting {
       return this;
     }
 
-    const userData = isV10orNewer() ? existingUser : existingUser.data;
+    const userData = existingUser;
 
     if (setting.core.color !== userData.color) {
       this.playerDifferences.color = new Difference(


### PR DESCRIPTION
Added full V13 support, including new namespaces, modernized  manifest, new Context Menu hook.
Dropped all support v12 and older versions of Foundry for better maintainability.

This PR however does not include support for new `user` scope of settings, which is something worth adding, as I imagine use of that setting scope will grow.

This PR also does not refactor Core app into AppV2, as that can wait a bit longer, just wanted to get the updated module out to people ;) 